### PR TITLE
allow to change container (for example FlexboxLayout powerful combina…

### DIFF
--- a/simpledialogfragment/src/main/java/eltos/simpledialogfragment/form/SimpleFormDialog.java
+++ b/simpledialogfragment/src/main/java/eltos/simpledialogfragment/form/SimpleFormDialog.java
@@ -310,14 +310,23 @@ public class SimpleFormDialog extends CustomViewDialog<SimpleFormDialog> {
 
     }
 
-
+    protected void setContainer(ViewGroup viewGroup) {
+        mFormContainer =  viewGroup;
+    }
 
     @Override
     public View onCreateContentView(Bundle savedInstanceState) {
         // inflate custom view
         View view = inflate(R.layout.simpledialogfragment_form);
-        mFormContainer = (ViewGroup) view.findViewById(R.id.container);
+        ViewGroup container = (ViewGroup) view.findViewById(R.id.container);
+        setContainer(container);
 
+        setFields(savedInstanceState);
+
+        return view;
+    }
+
+    protected void setFields(Bundle savedInstanceState) {
         ArrayList<FormElement> fields = getArguments().getParcelableArrayList(INPUT_FIELDS);
 
         if (fields != null) {
@@ -343,11 +352,7 @@ public class SimpleFormDialog extends CustomViewDialog<SimpleFormDialog> {
             }
 
         }
-
-        return view;
     }
-
-
 
 
     @Override

--- a/simpledialogfragment/src/main/res/values-pl/plurals.xml
+++ b/simpledialogfragment/src/main/res/values-pl/plurals.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <plurals name="at_least_x_chars">
+        <item quantity="one">Minimalnie 1 znak</item>
+        <item quantity="few">Minimalnie %1$d znaki</item>
+        <item quantity="many">Minimalnie %1$d znaków</item>
+    </plurals>
+
+</resources>

--- a/simpledialogfragment/src/main/res/values-pl/strings.xml
+++ b/simpledialogfragment/src/main/res/values-pl/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="email_address">Adres email</string>
+    <string name="invalid_email_address">Niepoprawny email</string>
+    <string name="transparency">Przezroczystość</string>
+    <string name="password">Hasło</string>
+    <string name="required">Wymagane</string>
+    <string name="input_not_a_given_option">Nieprawidłowa wartość</string>
+    <string name="name">Nazwa</string>
+    <string name="phone_number">Numer telefonu</string>
+    <string name="login">Login</string>
+    <string name="user">Użytkownik</string>
+    <string name="strong_pw_requirements">Musi zawierać cyfrę, małą i wielką literę oraz znak specjalny</string>
+    <string name="letters_only_error">Może zawierać jedynie litery (A-Z)</string>
+    <string name="alphanumeric_only_error">Może zawierać tylko znaki alfanumeryczne</string>
+</resources>


### PR DESCRIPTION
Hello,

If you allow to change Countainer for forms you can change LinearLayout to FlexboxLayout. Its pawerful comibination and you can build dynamic dialog with many items. You can make specific dialog's layout  for tablets. I send u example https://ibb.co/ks8rnb. With this change your library would be more elastic and pawerful.

![tablet_poziomo_dol_dialogu](https://user-images.githubusercontent.com/18366649/32417379-0f79d650-c259-11e7-96b4-e25cd51ffa83.png)


In the other way we can change this layout in your library and set default values to present in like LinearLayout  but it require add FlexboxLayout https://github.com/google/flexbox-layout (its from Google).

Reargs,
Witold Sieński

