### PR TITLE
Update to Android Oreo (API 27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # SimpleDialogFragments
 
-[ ![API 11+](https://img.shields.io/badge/API-11+-lightgrey.svg)](https://developer.android.com/about/dashboards/index.html#Platform)
+[ ![API 14+](https://img.shields.io/badge/API-14+-green.svg)](https://developer.android.com/about/dashboards/index.html#Platform)
 [ ![Download Latest](https://api.bintray.com/packages/eltos/simpledialogfragments/SimpleDialogFragment/images/download.svg) ](https://bintray.com/eltos/simpledialogfragments/SimpleDialogFragment/_latestVersion)
 [![Code Climate Rating](https://codeclimate.com/github/eltos/SimpleDialogFragments/badges/gpa.svg)](https://codeclimate.com/github/eltos/SimpleDialogFragments)
+[![License](https://img.shields.io/github/license/eltos/simpledialogfragments.svg)](https://github.com/eltos/SimpleDialogFragments#license)
 
 <img width="40%" align="right" src="https://github.com/eltos/SimpleDialogFragments/raw/master/wiki/simplecolorwheeldialog.png"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ plugins {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/simpledialogfragment/build.gradle
+++ b/simpledialogfragment/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 27
     buildToolsVersion '27.0.3'
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 25
-        versionCode 222
-        versionName "2.2.2"
+        minSdkVersion 14
+        targetSdkVersion 27
+        versionCode 300
+        versionName "3.0.0"
     }
     buildTypes {
         release {
@@ -21,8 +21,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.1'
-    compile 'com.android.support:design:25.1.1'
+    compile 'com.android.support:appcompat-v7:27.0.2'
+    compile 'com.android.support:design:27.0.2'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
 }
 
@@ -43,7 +43,7 @@ ext {
     gitUrl = 'https://github.com/eltos/SimpleDialogFragments.git'
     githubRepository= 'eltos/SimpleDialogFragments'
 
-    libraryVersion = '2.2.2'
+    libraryVersion = '3.0.0'
 
     developerId = 'eltos'
     developerName = 'Philipp Niedermayer'

--- a/testApp/build.gradle
+++ b/testApp/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 27
     buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "eltos.simpledialogfragments.test"
         minSdkVersion 14
-        targetSdkVersion 25
-        versionCode 222
-        versionName "2.2.2"
+        targetSdkVersion 27
+        versionCode 300
+        versionName "3.0.0"
     }
     buildTypes {
         release {
@@ -22,7 +22,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.1'
+    compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.google.zxing:core:3.2.0'
     compile project(path: ':simpledialogfragment')
 }


### PR DESCRIPTION
**Changes minSdk to 14 while dropping support for devices running API 11 to 13 (<0.1%)**
Still targeting 99.7% of active devices
See [API Dashboard](https://developer.android.com/about/dashboards/index.html)