### PR TITLE
Add progress dialog

### DIFF
--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/CustomViewDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/CustomViewDialog.java
@@ -82,9 +82,37 @@ public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
 	 * 
 	 * @param enabled whether to en- or disable the button
      */
-    protected final void setPositiveButtonEnabled(boolean enabled){
-        if (positiveButton != null) {
-            positiveButton.setEnabled(enabled);
+    public final void setPositiveButtonEnabled(boolean enabled){
+        if (getPositiveButton() != null) {
+            getPositiveButton().setEnabled(enabled);
+        }
+    }
+
+    /**
+     * Call this method to enable or disable the neutral button,
+     * e.g. if you want to consider for preconditions to be fulfilled
+     *
+     * Note: call this in {@link CustomViewDialog#onDialogShown} rather than {@link CustomViewDialog#onCreateContentView}
+     *
+     * @param enabled whether to en- or disable the button
+     */
+    public final void setNeutralButtonEnabled(boolean enabled){
+        if (getNeutralButton() != null) {
+            getNeutralButton().setEnabled(enabled);
+        }
+    }
+
+    /**
+     * Call this method to enable or disable the positive button,
+     * e.g. if you want to consider for preconditions to be fulfilled
+     *
+     * Note: call this in {@link CustomViewDialog#onDialogShown} rather than {@link CustomViewDialog#onCreateContentView}
+     *
+     * @param enabled whether to en- or disable the button
+     */
+    public final void setNegativeButtonEnabled(boolean enabled){
+        if (getNegativeButton() != null) {
+            getNegativeButton().setEnabled(enabled);
         }
     }
 
@@ -172,7 +200,6 @@ public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
     // Internal
 
 
-    private Button positiveButton;
     private LayoutInflater layoutInflater;
 
 
@@ -229,13 +256,15 @@ public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
         dialog.setOnShowListener(new DialogInterface.OnShowListener() {
             @Override
             public void onShow(DialogInterface d) {
-                positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
-                positiveButton.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        pressPositiveButton();
-                    }
-                });
+                Button positiveButton = getPositiveButton();
+                if (positiveButton != null) {
+                    positiveButton.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            pressPositiveButton();
+                        }
+                    });
+                }
                 onDialogShown();
 
             }

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/CustomViewDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/CustomViewDialog.java
@@ -23,6 +23,7 @@ import android.os.Bundle;
 import androidx.annotation.CallSuper;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import android.text.Html;
 import android.view.InflateException;
@@ -275,7 +276,7 @@ public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
 
     @Override
     @CallSuper
-    protected boolean callResultListener(int which, Bundle extras) {
+    protected boolean callResultListener(int which, @Nullable Bundle extras) {
         Bundle results = onResult(which);
         if (extras == null) extras = new Bundle();
         if (results != null) extras.putAll(results);

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/CustomViewDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/CustomViewDialog.java
@@ -46,6 +46,13 @@ import android.widget.TextView;
 public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
         extends SimpleDialog<This> {
 
+    public static final String TAG = "CustomViewDialog.";
+
+    private static final String
+            POSITIVE_BUTTON_ENABLED = TAG + "pos_enabled",
+            NEGATIVE_BUTTON_ENABLED = TAG + "neg_enabled",
+            NEUTRAL_BUTTON_ENABLED = TAG + "neu_enabled";
+
 
     public static CustomViewDialog build(){
         throw new java.lang.InstantiationError("Unintended abuse of the builder method. " +
@@ -84,6 +91,7 @@ public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
 	 * @param enabled whether to en- or disable the button
      */
     public final void setPositiveButtonEnabled(boolean enabled){
+        setArg(POSITIVE_BUTTON_ENABLED, enabled);
         if (getPositiveButton() != null) {
             getPositiveButton().setEnabled(enabled);
         }
@@ -98,6 +106,7 @@ public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
      * @param enabled whether to en- or disable the button
      */
     public final void setNeutralButtonEnabled(boolean enabled){
+        setArg(NEUTRAL_BUTTON_ENABLED, enabled);
         if (getNeutralButton() != null) {
             getNeutralButton().setEnabled(enabled);
         }
@@ -112,6 +121,7 @@ public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
      * @param enabled whether to en- or disable the button
      */
     public final void setNegativeButtonEnabled(boolean enabled){
+        setArg(NEGATIVE_BUTTON_ENABLED, enabled);
         if (getNegativeButton() != null) {
             getNegativeButton().setEnabled(enabled);
         }
@@ -257,6 +267,11 @@ public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
         dialog.setOnShowListener(new DialogInterface.OnShowListener() {
             @Override
             public void onShow(DialogInterface d) {
+                // restore button states
+                setPositiveButtonEnabled(getArgs().getBoolean(POSITIVE_BUTTON_ENABLED, true));
+                setNegativeButtonEnabled(getArgs().getBoolean(NEGATIVE_BUTTON_ENABLED, true));
+                setNeutralButtonEnabled(getArgs().getBoolean(NEUTRAL_BUTTON_ENABLED, true));
+                // set click listener
                 Button positiveButton = getPositiveButton();
                 if (positiveButton != null) {
                     positiveButton.setOnClickListener(new View.OnClickListener() {
@@ -266,6 +281,7 @@ public abstract class CustomViewDialog<This extends CustomViewDialog<This>>
                         }
                     });
                 }
+                // callback for subclasses
                 onDialogShown();
 
             }

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleDialog.java
@@ -95,7 +95,7 @@ public class SimpleDialog<This extends SimpleDialog<This>> extends DialogFragmen
     };
 
     @CallSuper
-    protected boolean callResultListener(int which, Bundle extras) {
+    protected boolean callResultListener(int which, @Nullable Bundle extras) {
         if (extras == null) extras = new Bundle();
         extras.putAll(getExtras());
         boolean handled = false;

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleDialog.java
@@ -35,6 +35,7 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.appcompat.app.AlertDialog;
 import android.text.Html;
 import android.util.TypedValue;
+import android.widget.Button;
 
 /**
  * An easy to use and extendable dialog fragment that displays a text message.
@@ -548,6 +549,18 @@ public class SimpleDialog<This extends SimpleDialog<This>> extends DialogFragmen
         dialog.setCancelable(isCancelable());
 
         return dialog;
+    }
+
+    protected @Nullable Button getPositiveButton(){
+        return dialog == null ? null : dialog.getButton(DialogInterface.BUTTON_POSITIVE);
+    }
+
+    protected @Nullable Button getNegativeButton(){
+        return dialog == null ? null : dialog.getButton(DialogInterface.BUTTON_NEGATIVE);
+    }
+
+    protected @Nullable Button getNeutralButton(){
+        return dialog == null ? null : dialog.getButton(DialogInterface.BUTTON_NEUTRAL);
     }
 
 

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleDialog.java
@@ -120,9 +120,7 @@ public class SimpleDialog<This extends SimpleDialog<This>> extends DialogFragmen
     private AlertDialog dialog;
 
     public SimpleDialog(){
-        Bundle args = getArguments();
-        if (args == null) args = new Bundle();
-        setArguments(args);
+        getArgs(); // init arguments to never equal null
         // positive button default
         pos(android.R.string.ok);
     }
@@ -156,6 +154,20 @@ public class SimpleDialog<This extends SimpleDialog<This>> extends DialogFragmen
             return getString((Integer) value);
         }
         return null;
+    }
+
+    /**
+     * null-save method to get arguments
+     * @return dialog arguments bundle
+     */
+    @NonNull
+    protected final Bundle getArgs(){
+        Bundle args = getArguments();
+        if (args == null){
+            args = new Bundle();
+            setArguments(args);
+        }
+        return args;
     }
 
     /**

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
@@ -163,13 +163,18 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
 
             // set percentage text if not disabled
             if (getArgs().getBoolean(PERCENTAGE)){
-                double percent;
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-                    percent = 1.0 * (mProgressBar.getProgress() - mProgressBar.getMin()) / (mProgressBar.getMax() -mProgressBar.getMin());
+                if (mProgressBar.isIndeterminate()) {
+                    updateProgressTextInternal(null);
                 } else {
-                    percent = 1.0 * mProgressBar.getProgress() / mProgressBar.getMax();
+                    double percent;
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                        percent = 1.0 * (mProgressBar.getProgress() - mProgressBar.getMin()) /
+                                (mProgressBar.getMax() - mProgressBar.getMin());
+                    } else {
+                        percent = 1.0 * mProgressBar.getProgress() / mProgressBar.getMax();
+                    }
+                    updateProgressTextInternal(NumberFormat.getPercentInstance().format(percent));
                 }
-                updateProgressTextInternal(NumberFormat.getPercentInstance().format(percent));
             }
         }
 

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
@@ -5,6 +5,7 @@ import android.view.View;
 import android.widget.ProgressBar;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog> {
 
@@ -13,8 +14,16 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
 
     private static final String
             INDETERMINATE = TAG + "indeterminate",
+            MAX = TAG + "max",
+            PROGRESS = TAG + "progress",
+            PROGRESS2 = TAG + "progress2",
             TYPE = TAG + "type";
 
+    /**
+     * Enum for various progress bar types.
+     * Can be set via {@link SimpleProgressDialog#type(Type)}
+     * Please note that some features might not be available depending on the chosen type
+     */
     public enum Type {BAR, CIRCLE};
 
 
@@ -24,7 +33,7 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
     public static SimpleProgressDialog bar(){
         return SimpleProgressDialog.build().type(Type.BAR);
     }
-    public static SimpleProgressDialog circle(){
+    public static SimpleProgressDialog indeterminateCircle(){
         return SimpleProgressDialog.build().type(Type.CIRCLE);
     }
 
@@ -36,9 +45,89 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
     }
 
 
+    /**
+     * Set the progress bar type to any of {@link SimpleProgressDialog.Type}
+     * Please note that some features might not be available depending on the chosen type
+     *
+     * @param type The progress bar type {@link SimpleProgressDialog.Type}
+     * @return this instance
+     */
     public SimpleProgressDialog type(Type type){
         return setArg(TYPE, type.ordinal());
     }
+
+
+    /**
+     * Set or update the progress before or while the dialog is shown.
+     *
+     * @param indeterminate indeterminate mode (or null to keep the previous value)
+     * @param progress primary progress (or null to keep the previous value)
+     * @param secondaryProgress secondary progress (if any, or null to keep the previous value)
+     * @param max maximum for progress (or null to keep the previous value)
+     */
+    public void updateProgress(@Nullable Boolean indeterminate, @Nullable Integer progress,
+                               @Nullable Integer secondaryProgress, @Nullable Integer max){
+        if (mProgressBar == null) {
+            // not yet shown, update arguments instead
+            if (indeterminate != null) setArg(INDETERMINATE, indeterminate);
+            if (progress != null) setArg(PROGRESS, progress);
+            if (secondaryProgress != null) setArg(PROGRESS2, secondaryProgress);
+            if (max != null) setArg(MAX, max);
+        } else {
+            // already shown, update progress bar
+            if (indeterminate != null) mProgressBar.setIndeterminate(indeterminate);
+            if (progress != null) mProgressBar.setProgress(progress);
+            if (secondaryProgress != null) mProgressBar.setSecondaryProgress(secondaryProgress);
+            if (max != null) mProgressBar.setMax(max);
+        }
+
+    }
+    /**
+     * Set or update the progress before or while the dialog is shown.
+     * This also sets indeterminate to false.
+     *
+     * @param progress primary progress
+     */
+    public void updateProgress(int progress){
+        updateProgress(false, progress, null, null);
+    }
+    /**
+     * Set or update the progress before or while the dialog is shown.
+     * This also sets indeterminate to false.
+     *
+     * @param progress primary progress
+     * @param max maximum for progress
+     */
+    public void updateProgress(int progress, int max){
+        updateProgress(false, progress, null, max);
+    }
+    /**
+     * Set or update the progress before or while the dialog is shown.
+     *
+     * @param max maximum for progress
+     */
+    public void updateMax(int max){
+        updateProgress(null, null, null, max);
+    }
+    /**
+     * Set or update the progress before or while the dialog is shown.
+     * This also sets indeterminate to false.
+     *
+     * @param progress secondary progress
+     */
+    public void updateSecondaryProgress(int progress){
+        updateProgress(false, null, progress, null);
+    }
+    /**
+     * Set or update the progress to be indeterminate before or while the dialog is shown.
+     * To set indeterminate to false, use {@link SimpleProgressDialog#updateProgress}
+     */
+    public void updateIndeterminate(){
+        updateProgress(true, null, null, null);
+    }
+
+
+
 
 
 
@@ -64,7 +153,10 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
         }
 
         mProgressBar.setVisibility(View.VISIBLE);
-        mProgressBar.setIndeterminate(savedInstanceState.getBoolean(INDETERMINATE, true));
+        updateProgress(savedInstanceState.getBoolean(INDETERMINATE, true),
+                       savedInstanceState.getInt(PROGRESS, 0),
+                       savedInstanceState.getInt(PROGRESS2, 0),
+                       savedInstanceState.getInt(MAX, 100));
 
         return view;
     }
@@ -73,6 +165,9 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(INDETERMINATE, mProgressBar.isIndeterminate());
+        outState.putInt(MAX, mProgressBar.getMax());
+        outState.putInt(PROGRESS, mProgressBar.getProgress());
+        outState.putInt(PROGRESS2, mProgressBar.getSecondaryProgress());
     }
 
 }

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
@@ -12,11 +12,20 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
     public static final String TAG = "SimpleProgressDialog.";
 
     private static final String
-            INDETERMINATE = TAG + "indeterminate";
+            INDETERMINATE = TAG + "indeterminate",
+            TYPE = TAG + "type";
+
+    public enum Type {BAR, CIRCLE};
 
 
     public static SimpleProgressDialog build(){
         return new SimpleProgressDialog();
+    }
+    public static SimpleProgressDialog bar(){
+        return SimpleProgressDialog.build().type(Type.BAR);
+    }
+    public static SimpleProgressDialog circle(){
+        return SimpleProgressDialog.build().type(Type.CIRCLE);
     }
 
     public SimpleProgressDialog(){
@@ -27,6 +36,9 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
     }
 
 
+    public SimpleProgressDialog type(Type type){
+        return setArg(TYPE, type.ordinal());
+    }
 
 
 
@@ -40,15 +52,19 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
         // inflate and set your custom view here
 
         View view = inflate(R.layout.simpledialogfragment_progress);
-        mProgressBar = view.findViewById(R.id.progress);
+        if (getArgs().getInt(TYPE) == Type.CIRCLE.ordinal()) {
+            mProgressBar = view.findViewById(R.id.progressCircle);
+        } else { // default: Type.BAR
+            mProgressBar = view.findViewById(R.id.progress);
+        }
 
 
         if (savedInstanceState == null){
             savedInstanceState = getArgs();
         }
-        if (savedInstanceState != null) {
-            mProgressBar.setIndeterminate(savedInstanceState.getBoolean(INDETERMINATE, true));
-        }
+
+        mProgressBar.setVisibility(View.VISIBLE);
+        mProgressBar.setIndeterminate(savedInstanceState.getBoolean(INDETERMINATE, true));
 
         return view;
     }

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
@@ -1,5 +1,6 @@
 package eltos.simpledialogfragment;
 
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
@@ -327,8 +328,8 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
     @CallSuper
     protected void onDialogShown() {
         if (mTask != null) {
-            setPositiveButtonEnabled(false);
-            updateIndeterminate(); // set to indeterminate until first progress is reported by task
+            setPositiveButtonEnabled(mTask.getStatus() == AsyncTask.Status.FINISHED);
+            setNeutralButtonEnabled(mTask.getStatus() != AsyncTask.Status.FINISHED);
         }
         super.onDialogShown();
     }

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
@@ -1,0 +1,62 @@
+package eltos.simpledialogfragment;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.ProgressBar;
+
+import androidx.annotation.NonNull;
+
+public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog> {
+
+
+    public static final String TAG = "SimpleProgressDialog.";
+
+    private static final String
+            INDETERMINATE = TAG + "indeterminate";
+
+
+    public static SimpleProgressDialog build(){
+        return new SimpleProgressDialog();
+    }
+
+    public SimpleProgressDialog(){
+        // defaults
+        cancelable(false); // not cancelable by back-button press
+        neut(android.R.string.cancel); // cancelable by cancel button
+        pos(null);
+    }
+
+
+
+
+
+    public ProgressBar mProgressBar;
+
+
+
+
+    @Override
+    protected View onCreateContentView(Bundle savedInstanceState) {
+        // inflate and set your custom view here
+
+        View view = inflate(R.layout.simpledialogfragment_progress);
+        mProgressBar = view.findViewById(R.id.progress);
+
+
+        if (savedInstanceState == null){
+            savedInstanceState = getArguments();
+        }
+        if (savedInstanceState != null) {
+            mProgressBar.setIndeterminate(savedInstanceState.getBoolean(INDETERMINATE, true));
+        }
+
+        return view;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(INDETERMINATE, mProgressBar.isIndeterminate());
+    }
+
+}

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
@@ -132,6 +132,7 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
             pos(null);
         } else {
             pos(android.R.string.ok);
+            setPositiveButtonEnabled(false);
         }
 
         return this;
@@ -324,15 +325,6 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
         return view;
     }
 
-    @Override
-    @CallSuper
-    protected void onDialogShown() {
-        if (mTask != null) {
-            setPositiveButtonEnabled(mTask.getStatus() == AsyncTask.Status.FINISHED);
-            setNeutralButtonEnabled(mTask.getStatus() != AsyncTask.Status.FINISHED);
-        }
-        super.onDialogShown();
-    }
 
     @Override
     @CallSuper

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
@@ -12,6 +12,11 @@ import androidx.annotation.Nullable;
 
 import java.text.NumberFormat;
 
+/**
+ * A dialog that displays a progress
+ *
+ * Created by eltos on 27.05.21.
+ */
 public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog> {
 
 

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
@@ -1,11 +1,15 @@
 package eltos.simpledialogfragment;
 
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.View;
 import android.widget.ProgressBar;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.text.NumberFormat;
 
 public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog> {
 
@@ -17,6 +21,9 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
             MAX = TAG + "max",
             PROGRESS = TAG + "progress",
             PROGRESS2 = TAG + "progress2",
+            PERCENTAGE = TAG + "percentage",
+            TEXT_PROGRESS = TAG + "text_progress",
+            TEXT_INFO = TAG + "text_info",
             TYPE = TAG + "type";
 
     /**
@@ -24,17 +31,33 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
      * Can be set via {@link SimpleProgressDialog#type(Type)}
      * Please note that some features might not be available depending on the chosen type
      */
-    public enum Type {BAR, CIRCLE};
+    public enum Type {
+        /**
+         * A horizontal progress bar
+         * {@link R.layout#simpledialogfragment_progress}
+         */
+        BAR,
+
+        /**
+         * A circle (only indeterminate)
+         * {@link R.layout#simpledialogfragment_progress_circle}
+         */
+        CIRCLE,
+    };
 
 
     public static SimpleProgressDialog build(){
         return new SimpleProgressDialog();
     }
     public static SimpleProgressDialog bar(){
-        return SimpleProgressDialog.build().type(Type.BAR);
+        return SimpleProgressDialog.build()
+                .type(Type.BAR)
+                .percentage(true);
     }
     public static SimpleProgressDialog indeterminateCircle(){
-        return SimpleProgressDialog.build().type(Type.CIRCLE);
+        return SimpleProgressDialog.build()
+                .type(Type.CIRCLE)
+                .percentage(false);
     }
 
     public SimpleProgressDialog(){
@@ -54,6 +77,16 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
      */
     public SimpleProgressDialog type(Type type){
         return setArg(TYPE, type.ordinal());
+    }
+
+    /**
+     * Whether to show the percentage text or not
+     *
+     * @param visible percentage text visible or not
+     * @return this instance
+     */
+    public SimpleProgressDialog percentage(boolean visible){
+        return setArg(PERCENTAGE, visible);
     }
 
 
@@ -79,6 +112,17 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
             if (progress != null) mProgressBar.setProgress(progress);
             if (secondaryProgress != null) mProgressBar.setSecondaryProgress(secondaryProgress);
             if (max != null) mProgressBar.setMax(max);
+
+            // set percentage text if not disabled
+            if (getArgs().getBoolean(PERCENTAGE)){
+                double percent;
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                    percent = 1.0 * (mProgressBar.getProgress() - mProgressBar.getMin()) / (mProgressBar.getMax() -mProgressBar.getMin());
+                } else {
+                    percent = 1.0 * mProgressBar.getProgress() / mProgressBar.getMax();
+                }
+                updateProgressTextInternal(NumberFormat.getPercentInstance().format(percent));
+            }
         }
 
     }
@@ -126,12 +170,46 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
         updateProgress(true, null, null, null);
     }
 
+    /**
+     * Set or update the progress text at the start of the progress bar /
+     * in the center of the circle
+     *
+     * @param text The text to show
+     */
+    public void updateProgressText(String text){
+        percentage(false);
+        updateProgressTextInternal(text);
+    }
+
+    private void updateProgressTextInternal(String text){
+        if (mProgressText != null) {
+            mProgressText.setText(text);
+            mProgressText.setVisibility(TextUtils.isEmpty(text) ? View.GONE : View.VISIBLE);
+        } else { // not yet shown, update arguments instead
+            setArg(TEXT_PROGRESS, text);
+        }
+    }
+
+    /**
+     * Set or update the info text at the end of the bar / next to the circle
+     *
+     * @param text The text to show
+     */
+    public void updateInfoText(String text){
+        if (mInfoText != null) {
+            mInfoText.setText(text);
+            mInfoText.setVisibility(TextUtils.isEmpty(text) ? View.GONE : View.VISIBLE);
+        } else { // not yet shown, update arguments instead
+            setArg(TEXT_INFO, text);
+        }
+    }
 
 
 
 
-
-    public ProgressBar mProgressBar;
+    protected ProgressBar mProgressBar;
+    protected TextView mProgressText;
+    protected TextView mInfoText;
 
 
 
@@ -140,19 +218,23 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
     protected View onCreateContentView(Bundle savedInstanceState) {
         // inflate and set your custom view here
 
-        View view = inflate(R.layout.simpledialogfragment_progress);
+        View view;
         if (getArgs().getInt(TYPE) == Type.CIRCLE.ordinal()) {
-            mProgressBar = view.findViewById(R.id.progressCircle);
+            view = inflate(R.layout.simpledialogfragment_progress_circle);
         } else { // default: Type.BAR
-            mProgressBar = view.findViewById(R.id.progress);
+            view = inflate(R.layout.simpledialogfragment_progress);
         }
+        mProgressBar = view.findViewById(R.id.progress);
+        mProgressText = view.findViewById(R.id.progressText);
+        mInfoText = view.findViewById(R.id.infoText);
 
 
         if (savedInstanceState == null){
             savedInstanceState = getArgs();
         }
 
-        mProgressBar.setVisibility(View.VISIBLE);
+        updateInfoText(savedInstanceState.getString(TEXT_INFO));
+        updateProgressTextInternal(savedInstanceState.getString(TEXT_PROGRESS));
         updateProgress(savedInstanceState.getBoolean(INDETERMINATE, true),
                        savedInstanceState.getInt(PROGRESS, 0),
                        savedInstanceState.getInt(PROGRESS2, 0),
@@ -168,6 +250,8 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
         outState.putInt(MAX, mProgressBar.getMax());
         outState.putInt(PROGRESS, mProgressBar.getProgress());
         outState.putInt(PROGRESS2, mProgressBar.getSecondaryProgress());
+        outState.putString(TEXT_INFO, String.valueOf(mInfoText.getText()));
+        outState.putString(TEXT_PROGRESS, String.valueOf(mProgressText.getText()));
     }
 
 }

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressDialog.java
@@ -44,7 +44,7 @@ public class SimpleProgressDialog extends CustomViewDialog<SimpleProgressDialog>
 
 
         if (savedInstanceState == null){
-            savedInstanceState = getArguments();
+            savedInstanceState = getArgs();
         }
         if (savedInstanceState != null) {
             mProgressBar.setIndeterminate(savedInstanceState.getBoolean(INDETERMINATE, true));

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressTask.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressTask.java
@@ -54,8 +54,8 @@ public abstract class SimpleProgressTask<Params, Progress, Result> extends Async
 
             if (values[0] instanceof Number){
                 v0 = (int) values[0];
-                if (values.length > 1) v1 = (int) values[0];
-                if (values.length > 2) v2 = (int) values[0];
+                if (values.length > 1) v1 = (int) values[1];
+                if (values.length > 2) v2 = (int) values[2];
             }
             if (values[0] instanceof String){
                 s0 = (String) values[0];

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressTask.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressTask.java
@@ -1,0 +1,74 @@
+package eltos.simpledialogfragment;
+
+import android.os.AsyncTask;
+import android.util.Pair;
+
+import androidx.annotation.CallSuper;
+
+public abstract class SimpleProgressTask<Params, Progress, Result> extends AsyncTask<Params, Progress, Result> {
+
+    protected SimpleProgressDialog mDialog;
+
+    protected void registerDialog(SimpleProgressDialog dialog){
+        mDialog = dialog;
+    }
+
+    @Override
+    @CallSuper
+    protected void onPreExecute() {
+        if (mDialog != null) {
+            mDialog.updateIndeterminate();
+        }
+    }
+
+    @Override
+    @CallSuper
+    protected void onPostExecute(Result result) {
+        if (mDialog != null) {
+            mDialog.updateFinished();
+        }
+    }
+
+    /**
+     * Updates the progress dialog by trying to guess the meaning of the supplied parameter(s):
+     *
+     * - if values is of numeric type
+     *   - if values[0] < 0, then progress is indeterminate
+     *   - if values[0] >= 0, then (int) values[0] is set as progress
+     *   - if values[1] > 0, then (int) values[1] is set as max, otherwise max defaults to 100
+     *   - if values[2] >= 0, then (int) values[2] is set as secondary progress
+     * - if values is of CharSequence type, then values[0] is set as info text and progress to indeterminate
+     * - if values is of type Pair<Numeric, String>, the above is applied to either value of the pair
+     */
+    @Override
+    protected void onProgressUpdate(Progress... values) {
+        if (mDialog != null && values.length > 0){
+            int v0 = -1, v1 = -1, v2 = -1;
+            String s0 = null;
+
+            if (values[0] instanceof Number){
+                v0 = (int) values[0];
+                if (values.length > 1) v1 = (int) values[0];
+                if (values.length > 2) v2 = (int) values[0];
+            }
+            if (values[0] instanceof String){
+                s0 = (String) values[0];
+                mDialog.updateIndeterminate();
+            }
+            if (values[0] instanceof Pair && ((Pair<?, ?>) values[0]).first instanceof Number && ((Pair<?, ?>) values[0]).second instanceof String){
+                v0 = (int) ((Pair<?, ?>) values[0]).first;
+                s0 = (String) ((Pair<?, ?>) values[0]).second;
+                if (values.length > 1) v1 = (int) ((Pair<?, ?>) values[1]).first;
+                if (values.length > 2) v2 = (int) ((Pair<?, ?>) values[2]).first;
+            }
+
+            if (v0 >= 0) mDialog.updateProgress(v0);
+            if (v0 < 0) mDialog.updateIndeterminate();
+            if (v1 > 0) mDialog.updateMax(v1);
+            if (v2 >= 0) mDialog.updateSecondaryProgress(v2);
+            mDialog.updateInfoText(s0);
+
+        }
+    }
+
+}

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressTask.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleProgressTask.java
@@ -5,6 +5,12 @@ import android.util.Pair;
 
 import androidx.annotation.CallSuper;
 
+/**
+ * An {@link AsyncTask} for use with {@link SimpleProgressDialog}
+ *
+ * Automatically reflects the task's states in the dialog.
+ *
+ */
 public abstract class SimpleProgressTask<Params, Progress, Result> extends AsyncTask<Params, Progress, Result> {
 
     protected SimpleProgressDialog mDialog;

--- a/simpledialogfragments/src/main/res/layout/simpledialogfragment_progress.xml
+++ b/simpledialogfragments/src/main/res/layout/simpledialogfragment_progress.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent" android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginRight="@dimen/activity_horizontal_margin"
+        android:layout_marginBottom="8dp" >
+
+        <ProgressBar
+            android:id="@+id/progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>

--- a/simpledialogfragments/src/main/res/layout/simpledialogfragment_progress.xml
+++ b/simpledialogfragments/src/main/res/layout/simpledialogfragment_progress.xml
@@ -16,6 +16,17 @@
             style="?android:attr/progressBarStyleHorizontal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ProgressBar
+            android:id="@+id/progressCircle"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/simpledialogfragments/src/main/res/layout/simpledialogfragment_progress_circle.xml
+++ b/simpledialogfragments/src/main/res/layout/simpledialogfragment_progress_circle.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
         android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="16dp"
         android:layout_marginRight="@dimen/activity_horizontal_margin"
-        android:layout_marginBottom="8dp" >
+        android:layout_marginBottom="8dp">
 
         <ProgressBar
             android:id="@+id/progress"
-            style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="match_parent"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:visibility="visible"
+            app:layout_constraintEnd_toStartOf="@+id/infoText"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -25,16 +27,25 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="00%"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/progress" />
+            app:layout_constraintBottom_toBottomOf="@id/progress"
+            app:layout_constraintEnd_toEndOf="@+id/progress"
+            app:layout_constraintStart_toStartOf="@+id/progress"
+            app:layout_constraintTop_toTopOf="@+id/progress" />
 
         <TextView
             android:id="@+id/infoText"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="64dp"
+            android:layout_marginLeft="64dp"
             android:text="Info"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/progress" />
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </RelativeLayout>

--- a/testApp/src/main/java/eltos/simpledialogfragments/MainActivity.java
+++ b/testApp/src/main/java/eltos/simpledialogfragments/MainActivity.java
@@ -59,6 +59,7 @@ import eltos.simpledialogfragment.SimpleCheckDialog;
 import eltos.simpledialogfragment.SimpleDateDialog;
 import eltos.simpledialogfragment.SimpleDialog;
 import eltos.simpledialogfragment.SimpleImageDialog;
+import eltos.simpledialogfragment.SimpleProgressDialog;
 import eltos.simpledialogfragment.SimpleTimeDialog;
 import eltos.simpledialogfragment.color.SimpleColorDialog;
 import eltos.simpledialogfragment.color.SimpleColorWheelDialog;
@@ -68,7 +69,6 @@ import eltos.simpledialogfragment.form.DateTime;
 import eltos.simpledialogfragment.form.Hint;
 import eltos.simpledialogfragment.form.Input;
 import eltos.simpledialogfragment.form.SimpleFormDialog;
-import eltos.simpledialogfragment.form.Spinner;
 import eltos.simpledialogfragment.input.SimpleInputDialog;
 import eltos.simpledialogfragment.input.SimplePinDialog;
 import eltos.simpledialogfragment.list.SimpleListDialog;
@@ -89,6 +89,7 @@ public class MainActivity extends AppCompatActivity implements
             CHECK_DIALOG = "dialogTagCheck",
             INPUT_DIALOG = "dialogTagInput",
             COLOR_DIALOG = "dialogTagColor",
+            PROGRESS_DIALOG = "dialogProgress",
             DATETIME_DIALOG_DATE = "dialogTagDateTimeDate",
             DATETIME_DIALOG_TIME = "dialogTagDateTimeTime",
             YES_NO_DIALOG = "dialogTagYesNo";
@@ -533,6 +534,19 @@ public class MainActivity extends AppCompatActivity implements
         /** Results: {@link MainActivity#onResult} **/
 
     }
+
+
+    // ==   P r o g r e s s   ==
+
+    public void showProgressIndeterminate(View view){
+
+        SimpleProgressDialog.build()
+                .title(R.string.login)
+                .msg(R.string.creating_user_profile_wait)
+                .show(this, PROGRESS_DIALOG);
+
+    }
+
 
 
     // ==   V a r i o u s   ==

--- a/testApp/src/main/java/eltos/simpledialogfragments/MainActivity.java
+++ b/testApp/src/main/java/eltos/simpledialogfragments/MainActivity.java
@@ -33,6 +33,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
+
 import android.text.InputType;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -540,10 +542,15 @@ public class MainActivity extends AppCompatActivity implements
 
     public void showProgressIndeterminate(View view){
 
-        SimpleProgressDialog.build()
+        SimpleProgressDialog.circle() // .bar() or .circle()
                 .title(R.string.login)
                 .msg(R.string.creating_user_profile_wait)
+                //.neut(null)
                 .show(this, PROGRESS_DIALOG);
+
+        //FragmentManager fm = getSupportFragmentManager();
+        //SimpleProgressDialog dialog = (SimpleProgressDialog) fm.findFragmentByTag(PROGRESS_DIALOG);
+        //dialog.dismiss();
 
     }
 

--- a/testApp/src/main/java/eltos/simpledialogfragments/MainActivity.java
+++ b/testApp/src/main/java/eltos/simpledialogfragments/MainActivity.java
@@ -542,7 +542,7 @@ public class MainActivity extends AppCompatActivity implements
 
     public void showProgressIndeterminate(View view){
 
-        SimpleProgressDialog.circle() // .bar() or .circle()
+        SimpleProgressDialog.bar() // .bar() or .indeterminateCircle()
                 .title(R.string.login)
                 .msg(R.string.creating_user_profile_wait)
                 //.neut(null)

--- a/testApp/src/main/res/layout/activity_main.xml
+++ b/testApp/src/main/res/layout/activity_main.xml
@@ -208,11 +208,31 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_row="1"
-                android:layout_column="0"
+                android:layout_column="1"
                 android:layout_columnWeight="1"
                 android:layout_margin="3dp"
                 android:onClick="showProgressIndeterminate"
                 android:text="Indeterminate" />
+
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_row="1"
+                android:layout_column="2"
+                android:layout_columnWeight="1"
+                android:layout_margin="3dp"
+                android:onClick="showProgressTask"
+                android:text="Task" />
+
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_row="1"
+                android:layout_column="3"
+                android:layout_columnWeight="1"
+                android:layout_margin="3dp"
+                android:onClick="showProgressCircle"
+                android:text="Circular" />
 
         </GridLayout>
 

--- a/testApp/src/main/res/layout/activity_main.xml
+++ b/testApp/src/main/res/layout/activity_main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="HardcodedText"
     tools:context="eltos.simpledialogfragments.MainActivity"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -186,6 +186,33 @@
                 android:layout_margin="3dp"
                 android:onClick="showMultiColorPicker"
                 android:text="N Colors" />
+
+        </GridLayout>
+
+        <GridLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:columnCount="4"
+            android:layout_marginBottom="@dimen/activity_vertical_margin">
+
+            <TextView
+                android:text="Progress"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_row="0"
+                android:layout_column="0"
+                android:layout_columnSpan="4"
+                android:textAppearance="?android:attr/textAppearanceLarge" />
+
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_row="1"
+                android:layout_column="0"
+                android:layout_columnWeight="1"
+                android:layout_margin="3dp"
+                android:onClick="showProgressIndeterminate"
+                android:text="Indeterminate" />
 
         </GridLayout>
 

--- a/testApp/src/main/res/values/strings.xml
+++ b/testApp/src/main/res/values/strings.xml
@@ -260,6 +260,7 @@
     <string name="ask_changes_discard_too_late">Oops, I\'m afraid I forgot about the changes you made. Sorry.</string>
     <string name="nevermind">Nevermind</string>
     <string name="replace">Replace</string>
+    <string name="creating_user_profile_wait">Please wait while a user profile is being created for you…</string>
 
 
 </resources>


### PR DESCRIPTION
- [x] Indeterminate type
- [x] Bar and indeterminate circle
- [x] Annotations (percent, info)
- [x] Methods to update progress
- [x] Simple connection with AsyncTask
- [x] Test for compatibility with rotation changes


closes #69


----------------------------------
Wiki page draft:

# Progress dialog

<img width="40%" align="right" src="https://raw.githubusercontent.com/wiki/eltos/SimpleDialogFragments/media/simpleprogressdialog_indeterminate.png"/>

*extends [CustomViewDialog](CustomViewDialog)*

A dialog showing a progress


## Building dialogs

The progress is indeterminate by default, but can be updated either before the dialog is shown or while it is being shown.
In addition, an `AsyncTask` can easily be connected to the dialog, such that the progress and state is automatically synced with the task.  
By default, a *cancel* button is shown, but the dialog can not be dismissed by (accidentally) clicking outside it or via the back button. This button can be removed via `.neut(null)`.  
The dialog is meant to be dismissed by calling `.dismiss()`, but an auto-dismiss option exists.

### Example

<img width="40%" align="right" src="https://raw.githubusercontent.com/wiki/eltos/SimpleDialogFragments/media/simpleprogressdialog.png"/>

```java
SimpleProgressDialog.bar()
                    .title(R.string.login)
                    .msg(R.string.creating_user_profile_wait)
                    .show(this, PROGRESS_DIALOG);
```
```java
// use this to access the dialog after rotation changes
FragmentManager fm = getSupportFragmentManager();
SimpleProgressDialog dialog = (SimpleProgressDialog) 
    fm.findFragmentByTag(PROGRESS_DIALOG);

dialog.updateProgress(13, 100);
dialog.updateInfoText("Working…");
dialog.dismiss();
```

More examples can be found in the [testApp](https://github.com/eltos/SimpleDialogFragments/blob/8bcf88c3191b66cf036339afd625d3feeafc2638/testApp/src/main/java/eltos/simpledialogfragments/MainActivity.java#L544-L619)


### Available customizations


<img width="40%" align="right" src="https://raw.githubusercontent.com/wiki/eltos/SimpleDialogFragments/media/simpleprogressdialog_circle.png"/>

* **Type (bar/circle)**  
`SimpleProgressDialog.bar()`
`SimpleProgressDialog.indeterminateCircle()`
`.type(Type type)`
*Please note that the circle type can only show an indeterminate progress*
* **Percentage indicator "00%" below bar/inside circle** (shown by default for bar type)  
`.percentage(boolean visible)`


See also [CustomViewDialog](CustomViewDialog)

## Updating the progress

These methods can be called either before the dialog is shown or afterwards.

**Progress**
`.updateProgress(int progress)`  
`.updateProgress(int progress, int max)`  
`.updateMax(int max)`  
`.updateSecondaryProgress(int progress)`  
`.updateIndeterminate()`  
`.updateFinished()`  

**Text**
`.updateProgressText(String text)` for a short text, e.g. 5% or 8MB (by default, this shows the progress unless manually set)  
`.updateInfoText(String text)` for a longer text, e.g. "Loading data…" or "5 seconds left"

## Working with AsyncTask

Derive a task from `SimpleProgressTask`.
```java
static class MyProgressTask extends SimpleProgressTask<Void, Integer, Void> {
    @Override
    protected Void doInBackground(Void... voids) {
        publishProgress(10); // 10% progress
        publishProgress(100, 500);  // 100/500 = 20% progress
        publishProgress(20, 100, 40);  // 20% primary and 40% secondary progress
        // ...
    }
    // if required, the full spectra of `mDialog.updateXXX(...)` methods can be called from a custom `onProgressUpdate` implementation
}
```

and link it to the dialog:
```java
MyTask task = new MyTask();
task.execute();

SimpleProgressDialog.bar()
        .title("...")
        .msg("...")
        .task(task, cancelable, autoDismiss) // optional cancel button and auto-dismiss functionality
        .show(this);
```

If `cancelable` is set and the cancel button is pressed, the task is canceled with `mayInterruptIfRunning=false`, so make sure to frequently check for `ìsCancelled()` in your tasks `doInBackground` method.  
If `autoDismiss` is set, the dialog will be dismissed once the task is finished and the `onResult` method will be called with `which=SimpleProgressDialog.COMPLETED`.

## Receiving results

See [SimpleDialog](SimpleDialog#receiving-results)






