### PR TITLE
Keybord does not appear for text fields in Android 11

### DIFF
--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/SimpleDialog.java
@@ -35,6 +35,8 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.appcompat.app.AlertDialog;
 import android.text.Html;
 import android.util.TypedValue;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 
 /**
@@ -558,6 +560,22 @@ public class SimpleDialog<This extends SimpleDialog<This>> extends DialogFragmen
 
     protected @Nullable Button getNeutralButton(){
         return dialog == null ? null : dialog.getButton(DialogInterface.BUTTON_NEUTRAL);
+    }
+
+    /**
+     * Helper for opening the soft keyboard on a specified view
+     */
+    public void showKeyboard(final View view){
+        view.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                view.requestFocus();
+                InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (imm != null) {
+                    imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT);
+                }
+            }
+        }, 100);
     }
 
 

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/InputViewHolder.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/InputViewHolder.java
@@ -248,7 +248,7 @@ class InputViewHolder extends FormElementViewHolder<Input> {
             // because only the input EditText gets focused here, not the entire layout
             // See: https://code.google.com/p/android/issues/detail?id=178153
             // Workaround is resizing the dialog
-            input.post(new Runnable() {
+            input.postDelayed(new Runnable() {
                 @Override
                 public void run() {
                     InputMethodManager imm = (InputMethodManager) input.getContext()
@@ -257,7 +257,7 @@ class InputViewHolder extends FormElementViewHolder<Input> {
                         imm.showSoftInput(input, InputMethodManager.SHOW_IMPLICIT);
                     }
                 }
-            });
+            }, 100);
         }
         if (field.forceSuggestion){
             input.showDropDown();

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/InputViewHolder.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/InputViewHolder.java
@@ -248,16 +248,7 @@ class InputViewHolder extends FormElementViewHolder<Input> {
             // because only the input EditText gets focused here, not the entire layout
             // See: https://code.google.com/p/android/issues/detail?id=178153
             // Workaround is resizing the dialog
-            input.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    InputMethodManager imm = (InputMethodManager) input.getContext()
-                            .getSystemService(Context.INPUT_METHOD_SERVICE);
-                    if (imm != null) {
-                        imm.showSoftInput(input, InputMethodManager.SHOW_IMPLICIT);
-                    }
-                }
-            }, 100);
+            actions.showKeyboard(input);
         }
         if (field.forceSuggestion){
             input.showDropDown();

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/SimpleFormDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/SimpleFormDialog.java
@@ -319,6 +319,13 @@ public class SimpleFormDialog extends CustomViewDialog<SimpleFormDialog> impleme
         }
 
         /**
+         * Helper for opening the soft keyboard on a specified view
+         */
+        public void showKeyboard(final View view){
+            SimpleFormDialog.this.showKeyboard(view);
+        }
+
+        /**
          * Helper to clear the current focus
          */
         public void clearCurrentFocus(){

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/input/SimpleInputDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/input/SimpleInputDialog.java
@@ -29,7 +29,6 @@ import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.TextView;
@@ -204,11 +203,7 @@ public class SimpleInputDialog extends CustomViewDialog<SimpleInputDialog> {
      * Helper for opening the soft keyboard
      */
     public void openKeyboard(){
-        InputMethodManager imm = (InputMethodManager) getActivity()
-                .getSystemService(Context.INPUT_METHOD_SERVICE);
-        if (imm != null) {
-            imm.showSoftInput(mInput, InputMethodManager.SHOW_IMPLICIT);
-        }
+        showKeyboard(mInput);
     }
 
     @Override
@@ -285,13 +280,7 @@ public class SimpleInputDialog extends CustomViewDialog<SimpleInputDialog> {
     @Override
     protected void onDialogShown() {
         setPositiveButtonEnabled(posEnabled());
-        mInput.requestFocus();
-        mInput.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                openKeyboard();
-            }
-        }, 100);
+        showKeyboard(mInput);
     }
 
     @Override

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/input/SimpleInputDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/input/SimpleInputDialog.java
@@ -285,8 +285,13 @@ public class SimpleInputDialog extends CustomViewDialog<SimpleInputDialog> {
     @Override
     protected void onDialogShown() {
         setPositiveButtonEnabled(posEnabled());
-        //mInput.requestFocus();
-        openKeyboard();
+        mInput.requestFocus();
+        mInput.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                openKeyboard();
+            }
+        }, 100);
     }
 
     @Override

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/input/SimplePinDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/input/SimplePinDialog.java
@@ -16,7 +16,6 @@
 
 package eltos.simpledialogfragment.input;
 
-import android.content.Context;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import com.google.android.material.textfield.TextInputLayout;
@@ -25,7 +24,6 @@ import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
 import com.alimuzaffar.lib.pin.PinEntryEditText;
@@ -134,11 +132,7 @@ public class SimplePinDialog extends CustomViewDialog<SimplePinDialog> {
      * Helper for opening the soft keyboard
      */
     public void openKeyboard(){
-        InputMethodManager imm = (InputMethodManager) getActivity()
-                .getSystemService(Context.INPUT_METHOD_SERVICE);
-        if (imm != null) {
-            imm.showSoftInput(mInput, InputMethodManager.SHOW_IMPLICIT);
-        }
+        showKeyboard(mInput);
     }
 
     @Override
@@ -206,8 +200,7 @@ public class SimplePinDialog extends CustomViewDialog<SimplePinDialog> {
     @Override
     protected void onDialogShown() {
         setPositiveButtonEnabled(posEnabled());
-        mInput.requestFocus();
-        openKeyboard();
+        showKeyboard(mInput);
     }
 
     @Override

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/list/CustomListDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/list/CustomListDialog.java
@@ -16,14 +16,12 @@
 
 package eltos.simpledialogfragment.list;
 
-import android.content.Context;
 import android.os.Bundle;
 import androidx.annotation.DimenRes;
 import androidx.annotation.StringRes;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.EditText;
@@ -451,11 +449,7 @@ public abstract class CustomListDialog<This extends CustomListDialog<This>>
         updatePosButton();
         if (getArgs().getBoolean(FILTER)){
             // show keyboard
-            InputMethodManager imm = (InputMethodManager) getActivity()
-                    .getSystemService(Context.INPUT_METHOD_SERVICE);
-            if (imm != null) {
-                imm.showSoftInput(mFilterEditText, InputMethodManager.SHOW_IMPLICIT);
-            }
+            showKeyboard(mFilterEditText);
         }
     }
 


### PR DESCRIPTION
### Add a description of the goal of this merge request

On Android 11, the keyboard does not seem to be appearing when using a text input field. 
On Android 10 and below, the keyboard appears just fine.  I noticed this behavior with the SimpleFormDialog and SimpleInputDialog.  


By introducing a postDelayed, the soft keyboard appears. Ref: https://stackoverflow.com/questions/5520085/android-show-softkeyboard-with-showsoftinput-is-not-working

Please reject or modify this PR if it isn't the right approach.  UI stuff is not my area of expertise, I'm just tinkering.


### Testing

Run the app on Android 11, or Android 11 emulator. 

Click "Text input" button.  When dialog appears, keyboard should also appear.  
Click "Form with different input types" button. When dialog appears, keyboard should also appear. 

Before: 

https://user-images.githubusercontent.com/746276/134811204-53910c64-1d74-4063-9655-ef7e9c22bd9f.mp4


After:


https://user-images.githubusercontent.com/746276/134811208-a96bd6c1-0f87-405d-8b16-722c2d193c52.mp4



