### PR TITLE
Allow to unset color (#92)

### DIFF
--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/ColorViewHolder.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/ColorViewHolder.java
@@ -22,6 +22,7 @@ import androidx.annotation.NonNull;
 
 import android.util.TypedValue;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import eltos.simpledialogfragment.R;
@@ -44,6 +45,8 @@ class ColorViewHolder extends FormElementViewHolder<ColorField> implements Simpl
     private TextView label;
     private ColorView colorView;
 
+    private ImageView clearButton;
+
     public ColorViewHolder(ColorField field) {
         super(field);
     }
@@ -59,6 +62,7 @@ class ColorViewHolder extends FormElementViewHolder<ColorField> implements Simpl
 
         label = (TextView) view.findViewById(R.id.label);
         colorView = (ColorView) view.findViewById(R.id.color);
+        clearButton = (ImageView) view.findViewById(R.id.clear_color);
 
         // Label
         String text = field.getText(context);
@@ -97,6 +101,15 @@ class ColorViewHolder extends FormElementViewHolder<ColorField> implements Simpl
             }
         });
 
+        if (!field.required) {
+            clearButton.setVisibility(View.VISIBLE);
+            clearButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    colorView.setColor(ColorView.NONE);
+                }
+            });
+        }
     }
 
 

--- a/simpledialogfragments/src/main/res/layout/simpledialogfragment_form_item_color.xml
+++ b/simpledialogfragments/src/main/res/layout/simpledialogfragment_form_item_color.xml
@@ -13,13 +13,30 @@
 
     <TextView
         android:id="@+id/label"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:layout_margin="4dp"
-        android:layout_weight="1"
         android:textAppearance="?android:attr/textAppearanceSmall"
         tools:text="Favourite color" />
+
+
+    <Space
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content" />
+
+    <ImageView
+        style="?actionButtonStyle"
+        android:id="@+id/clear_color"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_margin="6dp"
+        android:layout_gravity="center"
+        android:scaleType="fitCenter"
+        android:visibility="gone"
+        android:src="@drawable/ic_clear_search" />
+
 
 
 </LinearLayout>


### PR DESCRIPTION
This PR proposes a solution for #92 by adding a clear icon to the end of the ColorPicker form element. 

![Screenshot_1707520985](https://github.com/eltos/SimpleDialogFragments/assets/1485456/4786e400-4d57-4cfa-b5a6-97f009cbc078)


-----
My contribution follows "inbound=outbound" licensing as defined by the [GitHub Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license).