### PR TITLE
A11y: Allow to provide color names as content descriptions

### DIFF
--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/color/ColorView.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/color/ColorView.java
@@ -46,6 +46,8 @@ import android.widget.Checkable;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 
+import java.util.Locale;
+
 import eltos.simpledialogfragment.R;
 
 
@@ -108,12 +110,17 @@ public class ColorView extends FrameLayout implements Checkable {
         return mColor;
     }
 
+    /**
+     * Will implicitly set content description. Thus custom content description must be set after this
+     * method is called
+     */
     public void setColor(@ColorInt int color) {
         if ((color & 0xFF000000) == 0 && color != 0){ // if alpha value omitted, set now
             color = color | 0xFF000000;
         }
         if (mColor != color) {
             mColor = color;
+            setContentDescription(colorToRGBString(mColor));
             update();
         }
     }
@@ -289,6 +296,12 @@ public class ColorView extends FrameLayout implements Checkable {
         return Color.HSVToColor(hsv);
     }
 
+    public static String colorToRGBString(int color) {
+        int red = Color.red(color);
+        int green = Color.green(color);
+        int blue = Color.blue(color);
+        return String.format(Locale.ROOT, "RGB(%d, %d, %d)", red, green, blue);
+    }
 
 }
 

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/color/SimpleColorDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/color/SimpleColorDialog.java
@@ -23,6 +23,7 @@ import android.os.Bundle;
 import androidx.annotation.ArrayRes;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.core.util.Pair;
 
 import android.util.TypedValue;
 import android.view.View;
@@ -93,6 +94,28 @@ public class SimpleColorDialog extends CustomListDialog<SimpleColorDialog> imple
      */
     public SimpleColorDialog colors(Context context, @ArrayRes int colorArrayRes){
         return colors(context.getResources().getIntArray(colorArrayRes));
+    }
+
+    /**
+     * Sets the color names for accessibility purpose
+     *
+     * @param colorNames array of names that match the colors defined via {@link #colors(int[])}
+     * @return this instance
+     */
+    public SimpleColorDialog colorNames(String[] colorNames){
+        getArgs().putStringArray(COLOR_NAMES, colorNames);
+        return this;
+    }
+
+    /**
+     * Sets the color names for accessibility purpose
+     *
+     * @param context a context to resolve the resource
+     * @param colorNameArrayRes String array resource id
+     * @return this instance
+     */
+    public SimpleColorDialog colorNames(Context context, @ArrayRes int colorNameArrayRes){
+        return colorNames(context.getResources().getStringArray(colorNameArrayRes));
     }
 
     /**
@@ -183,9 +206,6 @@ public class SimpleColorDialog extends CustomListDialog<SimpleColorDialog> imple
         return setArg(OUTLINE, color);
     }
 
-
-
-
     public static final @ColorInt int[] DEFAULT_COLORS = new int[]{
             0xfff44336, 0xffe91e63, 0xff9c27b0, 0xff673ab7,
             0xff3f51b5, 0xff2196f3, 0xff03a9f4, 0xff00bcd4,
@@ -205,6 +225,8 @@ public class SimpleColorDialog extends CustomListDialog<SimpleColorDialog> imple
 
     private static final String SELECTED = TAG + "selected";
     private static final String OUTLINE = TAG + "outline";
+
+    private static final String COLOR_NAMES = TAG + "color_names";
 
     private @ColorInt int mCustomColor = NONE;
     private @ColorInt int mSelectedColor = NONE;
@@ -256,7 +278,7 @@ public class SimpleColorDialog extends CustomListDialog<SimpleColorDialog> imple
         // Selector provided by ColorView
         getListView().setSelector(new ColorDrawable(Color.TRANSPARENT));
 
-        return new ColorAdapter(colors, custom);
+        return new ColorAdapter(colors, getArgs().getStringArray(COLOR_NAMES), custom);
     }
 
     private int indexOf(int[] array, int item){
@@ -349,19 +371,19 @@ public class SimpleColorDialog extends CustomListDialog<SimpleColorDialog> imple
     }
 
 
-    protected class ColorAdapter extends AdvancedAdapter<Integer>{
+    protected class ColorAdapter extends AdvancedAdapter<Pair<Integer, String>>{
 
-        public ColorAdapter(int[] colors, boolean addCustomField){
+        public ColorAdapter(int[] colors, String[] contentDescriptions, boolean addCustomField){
             if (colors == null) colors = new int[0];
 
-            Integer[] cs = new Integer[colors.length + (addCustomField ? 1 : 0)];
+            Pair<Integer, String>[] cs = new Pair[colors.length + (addCustomField ? 1 : 0)];
             for (int i = 0; i < colors.length; i++) {
-                cs[i] = colors[i];
+                cs[i] = Pair.create(colors[i], contentDescriptions != null && contentDescriptions.length > i ? contentDescriptions[i] : null);
             }
             if (addCustomField){
-                cs[cs.length-1] = PICKER;
+                cs[cs.length-1] = Pair.create(PICKER, getString(R.string.color_picker));
             }
-            setData(cs, Long::valueOf);
+            setData(cs, pair -> pair.first.longValue());
         }
 
         @Override
@@ -374,15 +396,16 @@ public class SimpleColorDialog extends CustomListDialog<SimpleColorDialog> imple
                 item = new ColorView(getContext());
             }
 
-            int color = getItem(position);
+            Pair<Integer, String> pair = getItem(position);
 
-            if ( color == PICKER){
+            if (pair.first == PICKER){
                 item.setColor(mCustomColor);
                 item.setStyle(ColorView.Style.PALETTE);
             } else {
-                item.setColor(getItem(position));
+                item.setColor(pair.first);
                 item.setStyle(ColorView.Style.CHECK);
             }
+            item.setContentDescription(pair.second);
 
             @ColorInt int outline = getArgs().getInt(OUTLINE, ColorView.NONE);
             if (outline != NONE){

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/color/SimpleColorDialog.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/color/SimpleColorDialog.java
@@ -401,11 +401,14 @@ public class SimpleColorDialog extends CustomListDialog<SimpleColorDialog> imple
             if (pair.first == PICKER){
                 item.setColor(mCustomColor);
                 item.setStyle(ColorView.Style.PALETTE);
+                item.setContentDescription(getString(R.string.color_picker) + (mCustomColor == NONE ? "" : ": " + ColorView.colorToRGBString(mCustomColor)));
             } else {
                 item.setColor(pair.first);
                 item.setStyle(ColorView.Style.CHECK);
+                if (pair.second != null) {
+                    item.setContentDescription(pair.second);
+                }
             }
-            item.setContentDescription(pair.second);
 
             @ColorInt int outline = getArgs().getInt(OUTLINE, ColorView.NONE);
             if (outline != NONE){

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/ColorField.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/ColorField.java
@@ -44,6 +44,7 @@ public class ColorField extends FormElement<ColorField, ColorViewHolder> {
     private @ColorInt int preset = NONE;
     private int presetId = NO_ID;
     protected int[] colors = SimpleColorDialog.DEFAULT_COLORS;
+    protected String[] colorNames = null;
     protected boolean allowCustom = true;
     protected int outline = NONE;
 
@@ -98,6 +99,28 @@ public class ColorField extends FormElement<ColorField, ColorViewHolder> {
     public ColorField colors(@ColorInt int[] colors){
         this.colors = colors;
         return this;
+    }
+
+    /**
+     * Sets the color names for accessibility purpose
+     *
+     * @param colorNames array of names that match the colors defined via {@link #colors(int[])}
+     * @return this instance
+     */
+    public ColorField colorNames(String[] colorNames) {
+        this.colorNames = colorNames;
+        return this;
+    }
+
+    /**
+     * Sets the color names for accessibility purpose
+     *
+     * @param context a context to resolve the resource
+     * @param colorNameArrayRes String array resource id
+     * @return this instance
+     */
+    public ColorField colorNames(Context context, @ArrayRes int colorNameArrayRes){
+        return colorNames(context.getResources().getStringArray(colorNameArrayRes));
     }
 
     /**

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/ColorViewHolder.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/ColorViewHolder.java
@@ -88,6 +88,7 @@ class ColorViewHolder extends FormElementViewHolder<ColorField> implements Simpl
         colorView.setOnClickListener(v -> actions.showDialog(SimpleColorDialog.build()
                 .title(field.getText(context))
                 .colors(field.colors)
+                .colorNames(field.colorNames)
                 .allowCustom(field.allowCustom)
                 .colorPreset(colorView.getColor())
                 .neut(),
@@ -99,6 +100,14 @@ class ColorViewHolder extends FormElementViewHolder<ColorField> implements Simpl
 
     private void setColor(@ColorInt int color){
         colorView.setColor(color);
+        if(field.colorNames != null && field.colorNames.length >= field.colors.length) {
+            for (int i = 0; i < field.colors.length; i++) {
+                if (field.colors[i] == color) {
+                    colorView.setContentDescription(field.colorNames[i]);
+                    break;
+                }
+            }
+        }
         clearButton.setVisibility(field.required || colorView.getColor() == ColorView.NONE ? View.GONE : View.VISIBLE);
     }
 

--- a/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/ColorViewHolder.java
+++ b/simpledialogfragments/src/main/java/eltos/simpledialogfragment/form/ColorViewHolder.java
@@ -100,7 +100,7 @@ class ColorViewHolder extends FormElementViewHolder<ColorField> implements Simpl
 
     private void setColor(@ColorInt int color){
         colorView.setColor(color);
-        if(field.colorNames != null && field.colorNames.length >= field.colors.length) {
+        if (field.colorNames != null && field.colorNames.length >= field.colors.length) {
             for (int i = 0; i < field.colors.length; i++) {
                 if (field.colors[i] == color) {
                     colorView.setContentDescription(field.colorNames[i]);

--- a/simpledialogfragments/src/main/res/layout/simpledialogfragment_form_item_color.xml
+++ b/simpledialogfragments/src/main/res/layout/simpledialogfragment_form_item_color.xml
@@ -35,6 +35,7 @@
         android:layout_gravity="center"
         android:scaleType="fitCenter"
         android:visibility="gone"
+        android:contentDescription="@string/clear_color"
         android:src="@drawable/ic_clear_search" />
 
 

--- a/simpledialogfragments/src/main/res/values/strings.xml
+++ b/simpledialogfragments/src/main/res/values/strings.xml
@@ -20,4 +20,6 @@
     <string name="date">Date</string>
     <string name="time">Time</string>
     <string name="clear">Clear</string>
+    <string name="color_picker">Color picker</string>
+    <string name="clear_color">Clear color</string>
 </resources>

--- a/testApp/src/main/java/eltos/simpledialogfragments/MainActivity.java
+++ b/testApp/src/main/java/eltos/simpledialogfragments/MainActivity.java
@@ -393,13 +393,16 @@ public class MainActivity extends AppCompatActivity implements
                 pallet == SimpleColorDialog.BEIGE_COLOR_PALLET ? SimpleColorDialog.AUTO :
                         SimpleColorDialog.NONE;
 
-        SimpleColorDialog.build()
+        SimpleColorDialog dialog = SimpleColorDialog.build()
                 .title(R.string.pick_a_color)
                 .colors(this, pallet)
                 .colorPreset(color)
                 .allowCustom(true)
-                .showOutline(outline)
-                .show(this, COLOR_DIALOG);
+                .showOutline(outline);
+        if (pallet == SimpleColorDialog.MATERIAL_COLOR_PALLET) {
+            dialog.colorNames(this, R.array.material_color_names);
+        }
+        dialog.show(this, COLOR_DIALOG);
 
         /** Results: {@link MainActivity#onResult} **/
 
@@ -551,7 +554,9 @@ public class MainActivity extends AppCompatActivity implements
                         Input.plain(COUNTRY).hint(R.string.country)
                                 .inputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES)
                                 .suggest(R.array.countries_locale).forceSuggestion(),
-                        ColorField.picker(COLOR).label(R.string.favourite_color),
+                        ColorField.picker(COLOR).colors(SimpleColorDialog.DEFAULT_COLORS)
+                                .colorNames(this,R.array.material_color_names)
+                                .label(R.string.favourite_color),
                         Input.email(EMAIL).required(),
                         Check.box(NEWSLETTER).label(R.string.receive_newsletter).check(true),
                         Input.password(PASSWORD).max(20).required().validatePatternStrongPassword(),

--- a/testApp/src/main/res/values/arrays.xml
+++ b/testApp/src/main/res/values/arrays.xml
@@ -73,5 +73,25 @@
         <item>Intersex</item>
         <item>Dyadic</item>
     </string-array>
-
+    <string-array name="material_color_names">
+        <item>red</item>
+        <item>magenta</item>
+        <item>purple</item>
+        <item>deep purple</item>
+        <item>indigo</item>
+        <item>blue</item>
+        <item>light blue</item>
+        <item>cyan</item>
+        <item>teal</item>
+        <item>green</item>
+        <item>light green</item>
+        <item>lime</item>
+        <item>yellow</item>
+        <item>amber</item>
+        <item>orange</item>
+        <item>deep orange</item>
+        <item>brown</item>
+        <item>gray</item>
+        <item>blue gray</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
<!-- Add a description of the goal of this merge request -->

Google Play's pre-launch report runs AccesibilityScanner on my app and detected missing content descriptions in the color dialogue:
![grafik](https://github.com/user-attachments/assets/d85ee541-aa74-4a12-9e07-a6d2e3062b5b)

This change allows the user of the library to provide an array of color names matching the provided array of colors. If no color names are provided, the RGB value of the color will be set as content description.

This follows the following recommendation for accessible software:  https://handreichungen.bfit-bund.de/accessible-uie/farbwaehler.html


<!-- List all introduced changes, features, etc. -->

- Extend SimpleColorDialog and ColorField to accept an array of color names.

### Testing

Added the new field to the test App.

<!-- Add screenshots/outputs/etc. of the behaviour before/after your changes -->

No visible change. Just Talkback can provide user with names for selected colors.

-----
My contribution follows "inbound=outbound" licensing as defined by the [GitHub Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license).